### PR TITLE
added code examples links for widget

### DIFF
--- a/docs/widget/html.md
+++ b/docs/widget/html.md
@@ -22,6 +22,8 @@ tags:
 
 This guide walks you through integrating the **MyTonSwap Widget** into a web page using plain HTML and JavaScript. This setup is ideal for projects that do not use frameworks like React or Vue.
 
+👨‍💻 [Code Example](https://github.com/MyTonSwap/widget/tree/main/examples/html)
+
 ## Prerequisites
 
 -   A basic understanding of HTML and JavaScript.

--- a/docs/widget/introduction.md
+++ b/docs/widget/introduction.md
@@ -26,6 +26,8 @@ slug: /
 
 #### 🌐 Demo & Preview : https://widget.mytonswap.com
 
+#### 👨‍💻 Code Example : [HTML](https://github.com/MyTonSwap/widget/tree/main/examples/html), [React](https://github.com/MyTonSwap/widget/tree/main/examples/react), [Vue](https://github.com/MyTonSwap/widget/tree/main/examples/vue)
+
 # MyTonSwap Widget Documentation
 
 Welcome to the **MyTonSwap Widget**—your ultimate solution for integrating the MyTonSwap DEX aggregator directly into your web application. The MyTonSwap Widget provides a seamless and user-friendly interface for swapping tokens on the TON blockchain, while leveraging the best available rates from multiple decentralized exchanges (DEXs).

--- a/docs/widget/react.md
+++ b/docs/widget/react.md
@@ -21,6 +21,8 @@ tags:
 
 This guide will show you how to integrate the **MyTonSwap Widget** into your ReactJS application.
 
+👨‍💻 [Code Example](https://github.com/MyTonSwap/widget/tree/main/examples/react)
+
 ## Prerequisites
 
 -   A ReactJS application (you can create one with `create-react-app` or any other React setup).

--- a/docs/widget/vue.md
+++ b/docs/widget/vue.md
@@ -21,6 +21,8 @@ tags:
 
 **Widget example for Vue.js using a package manager**
 
+👨‍💻 [Code Example](https://github.com/MyTonSwap/widget/tree/main/examples/vue)
+
 ## Install the Widget using a Package Manager
 
 To start, install the **MyTonSwap Widget** using your preferred package manager:


### PR DESCRIPTION
This pull request includes updates to the documentation for the MyTonSwap Widget. The changes add code example links to the HTML, React, and Vue integration guides.

Documentation updates:

* [`docs/widget/html.md`](diffhunk://#diff-9527d9570d02d4747f17c5717a35aa1edbe3d8fdd1e0ae52c03851deaf42cf6eR25-R26): Added a link to the HTML code example.
* [`docs/widget/introduction.md`](diffhunk://#diff-e3db54b88572614d047d6572e1b1fd52ef15acbd4433f2cfdda7377ad77610b8R29-R30): Added links to the HTML, React, and Vue code examples.
* [`docs/widget/react.md`](diffhunk://#diff-6260c3ab1f0f40543fdcd3644af48ded2dee4313f1086f862a85926adacfb01cR24-R25): Added a link to the React code example.
* [`docs/widget/vue.md`](diffhunk://#diff-1e8c8a845e2917d7140a641b8f5b8a17a5d60da3d09b2a6f18da2812a5e70ed7R24-R25): Added a link to the Vue code example.